### PR TITLE
Apply brand tokens and redesign portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Your Name – Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Orbitron:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -12,9 +15,9 @@
     <div class="container nav-container">
       <img src="logo.svg" alt="Your Logo" class="nav-logo" />
       <ul class="nav-links">
-        <li><a href="#">Work</a></li>
-        <li><a href="#">About</a></li>
-        <li><a href="#">Contact</a></li>
+        <li><a href="#work">Work</a></li>
+        <li><a href="#brands">Brands</a></li>
+        <li><a href="#contact">Contact</a></li>
       </ul>
     </div>
   </nav>
@@ -27,7 +30,7 @@
   </header>
 
   <!-- Logo Wall Section -->
-  <section class="logo-wall">
+  <section id="brands" class="logo-wall">
     <div class="container">
       <h2>Brands I've Worked With</h2>
       <div class="logo-flex">
@@ -40,7 +43,7 @@
   </section>
 
   <!-- Video Grid Section -->
-  <section class="project-grid-section">
+  <section id="work" class="project-grid-section">
     <div class="container">
       <h2>Featured Work</h2>
       <div class="project-grid">
@@ -64,9 +67,12 @@
   </div>
 
   <!-- Contact Form -->
-  <section class="contact-section">
+  <section id="contact" class="contact-section">
     <div class="container">
       <h2>Contact</h2>
+      <div class="contact-actions">
+        <a class="btn" href="mailto:your@example.com">Email Me</a>
+      </div>
       <iframe src="https://docs.google.com/forms/d/e/YOUR_FORM_ID/viewform?embedded=true" width="100%" height="600" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
     </div>
   </section>
@@ -88,17 +94,33 @@
     const popup = document.getElementById('videoPopup');
     const frame = document.getElementById('videoFrame');
     const closeBtn = document.getElementById('closePopup');
+    const logo = document.querySelector('.nav-logo');
 
     cards.forEach(card => {
       card.addEventListener('click', () => {
         frame.src = card.dataset.video;
-        popup.style.display = 'flex';
+        popup.classList.add('active');
       });
     });
 
     closeBtn.addEventListener('click', () => {
-      popup.style.display = 'none';
+      popup.classList.remove('active');
       frame.src = '';
+    });
+
+    document.querySelectorAll('.nav-links a').forEach(link => {
+      link.addEventListener('click', e => {
+        const targetId = link.getAttribute('href');
+        if (targetId.startsWith('#')) {
+          e.preventDefault();
+          const target = document.querySelector(targetId);
+          if (target) target.scrollIntoView({ behavior: 'smooth' });
+        }
+      });
+    });
+
+    logo.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     });
   </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,38 @@
+@import url('theme-tokens.css');
+
 /* Base styles */
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
+html {
+  scroll-behavior: smooth;
+}
 body {
-  font-family: 'Helvetica Neue', sans-serif;
-  background-color: #111;
-  color: #eee;
+  font-family: var(--font-body);
+  background-color: var(--color-charcoal);
+  color: var(--color-white);
   line-height: 1.6;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
 }
 a {
   color: inherit;
   text-decoration: none;
+}
+.btn {
+  display: inline-block;
+  background: var(--color-aqua);
+  color: var(--color-black);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-elevated);
 }
 img, video {
   max-width: 100%;
@@ -28,8 +48,9 @@ img, video {
 
 /* Navigation */
 .site-header {
-  background: #111;
-  padding: 1rem 0;
+  background: var(--color-black-translucent);
+  backdrop-filter: blur(4px);
+  padding: var(--space-md) 0;
   position: sticky;
   top: 0;
   z-index: 10;
@@ -41,18 +62,32 @@ img, video {
 }
 .nav-logo {
   height: 40px;
+  cursor: pointer;
 }
 .nav-links {
   list-style: none;
   display: flex;
-  gap: 2rem;
+  gap: var(--space-lg);
 }
 .nav-links li a {
+  position: relative;
+  padding-bottom: var(--space-xs);
   font-weight: 500;
-  transition: color 0.3s;
+  transition: color var(--transition-medium);
 }
-.nav-links li a:hover {
-  color: #0ff;
+.nav-links li a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 2px;
+  background: var(--color-aqua);
+  box-shadow: 0 0 8px var(--color-aqua);
+  transition: width var(--transition-medium);
+}
+.nav-links li a:hover::after {
+  width: 100%;
 }
 
 /* Reel Video */
@@ -64,20 +99,20 @@ img, video {
 
 /* Logo Wall */
 .logo-wall {
-  padding: 4rem 0;
+  padding: var(--space-xxl) 0;
   text-align: center;
 }
 .logo-flex {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 2rem;
-  margin-top: 2rem;
+  gap: var(--space-lg);
+  margin-top: var(--space-lg);
 }
 .logo-flex img {
   height: 40px;
   opacity: 0.8;
-  transition: transform 0.3s;
+  transition: transform var(--transition-medium);
 }
 .logo-flex img:hover {
   transform: scale(1.1);
@@ -86,23 +121,26 @@ img, video {
 
 /* Project Grid */
 .project-grid-section {
-  padding: 4rem 0;
+  padding: var(--space-xxl) 0;
 }
 .project-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
-  margin-top: 2rem;
+  gap: var(--space-lg);
+  margin-top: var(--space-lg);
 }
 .project-card {
   cursor: pointer;
   overflow: hidden;
-  border-radius: 10px;
-  transition: transform 0.3s, box-shadow 0.3s;
+  background: var(--color-charcoal);
+  border: 1px solid var(--color-white-alpha-20);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  transition: transform var(--transition-medium), box-shadow var(--transition-medium);
 }
 .project-card:hover {
-  transform: scale(1.02);
-  box-shadow: 0 10px 20px rgba(0,0,0,0.4);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-elevated);
 }
 
 /* Popup Video Player */
@@ -110,11 +148,18 @@ img, video {
   position: fixed;
   top: 0; left: 0;
   width: 100%; height: 100%;
-  background: rgba(0,0,0,0.8);
-  display: none;
+  background: var(--color-black-alpha-80);
+  display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition-medium);
   z-index: 999;
+}
+.video-popup.active {
+  opacity: 1;
+  visibility: visible;
 }
 .popup-content {
   position: relative;
@@ -132,44 +177,48 @@ img, video {
   top: -40px;
   right: 0;
   font-size: 2rem;
-  color: #fff;
+  color: var(--color-white);
   cursor: pointer;
 }
 
 /* Contact Section */
 .contact-section {
-  padding: 4rem 0;
-  background: #1a1a1a;
+  padding: var(--space-xxl) 0;
+  background: var(--color-charcoal);
 }
 .contact-section h2 {
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: var(--space-lg);
+}
+.contact-actions {
+  text-align: center;
+  margin-bottom: var(--space-lg);
 }
 
 /* Footer */
 .footer {
-  padding: 2rem 0;
+  padding: var(--space-lg) 0;
   text-align: center;
-  background: #000;
+  background: var(--color-black);
 }
 .footer-logo {
   height: 30px;
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-sm);
 }
 .social-links a {
-  margin: 0 1rem;
-  color: #888;
-  transition: color 0.3s;
+  margin: 0 var(--space-sm);
+  color: var(--color-gray);
+  transition: color var(--transition-medium);
 }
 .social-links a:hover {
-  color: #0ff;
+  color: var(--color-aqua);
 }
 
 /* Responsive tweaks */
 @media (max-width: 600px) {
   .nav-links {
     flex-direction: column;
-    gap: 1rem;
+    gap: var(--space-md);
   }
   .nav-container {
     flex-direction: column;

--- a/theme-tokens.css
+++ b/theme-tokens.css
@@ -1,0 +1,27 @@
+:root {
+  --color-aqua: #00f5ff;
+  --color-charcoal: #111111;
+  --color-black: #000000;
+  --color-white: #ffffff;
+  --color-white-alpha-20: rgba(255, 255, 255, 0.2);
+  --color-black-translucent: rgba(0, 0, 0, 0.6);
+  --color-gray: #888888;
+  --color-black-alpha-80: rgba(0, 0, 0, 0.8);
+
+  --font-display: 'Orbitron', sans-serif;
+  --font-body: 'Inter', sans-serif;
+
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-xxl: 64px;
+
+  --radius-sm: 6px;
+  --radius-md: 12px;
+
+  --transition-fast: 150ms ease;
+  --transition-medium: 300ms ease;
+  --shadow-elevated: 0 10px 20px rgba(0,0,0,0.4);
+}

--- a/theme-tokens.json
+++ b/theme-tokens.json
@@ -1,0 +1,35 @@
+{
+  "color": {
+    "aqua": "#00f5ff",
+    "charcoal": "#111111",
+    "black": "#000000",
+    "white": "#ffffff",
+    "whiteAlpha20": "rgba(255,255,255,0.2)",
+    "blackTranslucent": "rgba(0,0,0,0.6)",
+    "gray": "#888888",
+    "blackAlpha80": "rgba(0,0,0,0.8)"
+  },
+  "font": {
+    "display": "Orbitron, sans-serif",
+    "body": "Inter, sans-serif"
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px",
+    "xxl": "64px"
+  },
+  "radius": {
+    "sm": "6px",
+    "md": "12px"
+  },
+  "motion": {
+    "fast": "150ms ease",
+    "medium": "300ms ease"
+  },
+  "shadow": {
+    "elevated": "0 10px 20px rgba(0,0,0,0.4)"
+  }
+}


### PR DESCRIPTION
## Summary
- integrate theme design tokens and import Orbitron and Inter font families
- revamp site styles: tokenized navbar, buttons, cards, footer and fade-in video popup
- enable smooth scrolling and logo scroll-to-top interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a16ed9870832bb640d2f39450128f